### PR TITLE
Saving conversation & interactive prompting in terminal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+conversations/
+checkpoints/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Llama-Agents
 
-This repository aims to create a collection of LLaMA 3 agents using LangChain The ultimate goal is to develop a suite of agents that can be used for various task and have access to different tools. The LLM will be self-hosted.
+This repository aims to create a collection of LLaMA 3 agents using LangChain. The ultimate goal is to develop a suite of agents that can be used for various tasks and have access to different tools. The LLM will be self-hosted.
+
 **Agents Developed:**
 
+0. **Simple Agent**: Simple Llama 3 agent accessible from the command line with answers recorded in markdown files.
 1. **Conversational Agent**: A conversational agent that can engage with users in natural language, answering questions and providing helpful responses and saving the conversations in files when requested.
 2. **Orchestrator Agent**: An orchestration agent that can manage multiple tasks and workflows, streamlining processes and automating repetitive tasks.
 3. **RAG (Rule-based Action Generator) Agent**: A rule-based agent that can generate actions based on predefined rules and conditions.
@@ -18,8 +20,43 @@ This repository aims to create a collection of LLaMA 3 agents using LangChain Th
 **Getting Started:**
 
 1. Clone this repository to your local machine.
-2. Install the required dependencies, including Ollama, Llama3 and Python.
-3. Run the scripts to call the agent of your choice.
-...
+2. Install the required dependencies, including Ollama, Llama3, and Python.
+3. Run the `main.py` script to interact with the Simple Agent.
+
+**Using the Simple Agent (`main.py`):**
+
+1. Open a terminal and navigate to the project directory.
+2. Run the following command to start a new conversation:
+   ```
+   python main.py
+   ```
+   This will create a new conversation file in the `conversations` directory with the current timestamp.
+
+3. To continue an existing conversation, run the following command:
+   ```
+   python main.py -c
+   ```
+   This will load the conversation from the last used conversation file.
+
+4. Enter your prompt or question when prompted. The agent will process your input and generate a response, which will be displayed in the terminal and saved to the conversation file.
+
+5. To start a new conversation at any point, type `new` and press Enter. This will create a new conversation file and switch to it.
+
+6. To exit the program, type `exit` and press Enter.
+
+**Conversation Files:**
+
+The conversations are saved in markdown format in the `conversations` directory. Each conversation is stored in a separate file named `conversation_<timestamp>.md`.
+
+The conversation files contain the user prompts and the assistant's responses, along with the response time. If a response is interrupted due to early stoppage, it will be marked as "Interrupted" in the conversation file.
+
+**Note:**
+
+- The Simple Agent uses the LLaMA 3 model, which needs to be set up and configured separately.
+- Make sure to have the necessary dependencies installed before running the script.
+- The conversation files are encoded in UTF-8 to ensure proper display of special characters.
+
+... 
+
 [1] LangChain documentation: <https://docs.langchain.com/>
 [2] LLaMA 3 documentation: <https://www.llama3.ai/docs/>

--- a/config.json
+++ b/config.json
@@ -1,0 +1,1 @@
+{"filename": "", "current_conversation": "conversation_20240426_113652.md"}

--- a/main.py
+++ b/main.py
@@ -1,23 +1,112 @@
+import os
+import sys
+import json
+import time
+from datetime import datetime
 from langchain_community.llms import Ollama
 from langchain_core.prompts import PromptTemplate
 
 # Load the LLaMA3 model
-llm  = Ollama(model="llama3:8b")
+llm = Ollama(model="llama3:8b")
 
-def call_llma(prompt):
-  
-    #for chunks in llm.stream(prompt, stop=["<|eot_id|>"]):
-      #  print(chunks)
-    try:
-        # Use the invoke method to get a response, handling the stop condition
-            response = llm.invoke(prompt, stop=["<|eot_id|>"])
-            return response
-    except Exception as e:
-        print("An error occurred:", e)
-        return None
+def call_llma(prompt, conversation_file):
+    start_time = time.time()
+    response = ""
+    checkpoint_file = os.path.join("checkpoints", f"{conversation_file}.checkpoint")
     
+    try:
+        for chunk in llm.stream(prompt, stop=["<|eot_id|>"]):
+            sys.stdout.write(chunk)
+            sys.stdout.flush()
+            response += chunk
+            
+            # Save the current response as a checkpoint
+            os.makedirs(os.path.dirname(checkpoint_file), exist_ok=True)
+            with open(checkpoint_file, "w", encoding="utf-8") as file:
+                file.write(response)
+        
+        # Remove the checkpoint file after successful completion
+        os.remove(checkpoint_file)
+    except KeyboardInterrupt:
+        print("\nStreaming interrupted. Saving the partial response.")
+    
+    end_time = time.time()
+    response_time = end_time - start_time
+    
+    print()  # Print a new line after streaming the response
+    
+    return response, response_time
 
-# Example usage:
-prompt = "What is the capital of France?"
-response = call_llma(prompt)
-print(response)
+def create_new_conversation():
+    # Generate a unique filename based on the current timestamp
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"conversation_{timestamp}.md"
+    
+    # Create the conversations directory if it doesn't exist
+    os.makedirs("conversations", exist_ok=True)
+    
+    # Create the new conversation file
+    with open(os.path.join("conversations", filename), "w", encoding="utf-8") as file:
+        file.write(f"# Conversation {timestamp}\n\n")
+    
+    # Update the current conversation filename in the config file
+    update_config(filename)
+    
+    return filename
+
+def save_conversation(filename, prompt, response, response_time, interrupted=False):
+    with open(os.path.join("conversations", filename), "a", encoding="utf-8") as file:
+        file.write(f"## User Prompt:\n{prompt}\n\n")
+        if interrupted:
+            file.write(f"## Assistant Response (Interrupted, Time: {response_time:.2f} seconds):\n{response}\n\n")
+        else:
+            file.write(f"## Assistant Response (Time: {response_time:.2f} seconds):\n{response}\n\n")
+
+def load_config():
+    if os.path.exists("config.json"):
+        with open("config.json", "r") as file:
+            return json.load(file)
+    return {}
+
+def update_config(filename):
+    config = load_config()
+    config["current_conversation"] = filename
+    with open("config.json", "w") as file:
+        json.dump(config, file)
+
+if __name__ == "__main__":
+    continue_conversation = False
+    
+    if len(sys.argv) > 1 and sys.argv[1] == "-c":
+        continue_conversation = True
+    
+    if continue_conversation:
+        config = load_config()
+        conversation_file = config.get("current_conversation")
+        
+        if conversation_file is None or conversation_file == "":
+            print("No existing conversation found. Starting a new conversation.")
+            conversation_file = create_new_conversation()
+        else:
+            print(f"Continuing conversation: {conversation_file}")
+    else:
+        conversation_file = create_new_conversation()
+        print(f"New conversation created: {conversation_file}")
+    
+    while True:
+        prompt = input("Enter your prompt (or type 'exit' to quit, 'new' to start a new conversation): ")
+        
+        if prompt.lower() == "exit":
+            break
+        elif prompt.lower() == "new":
+            conversation_file = create_new_conversation()
+            print(f"New conversation created: {conversation_file}")
+            continue
+        
+        response, response_time = call_llma(prompt, conversation_file)
+        interrupted = False
+        
+        if os.path.exists(os.path.join("checkpoints", f"{conversation_file}.checkpoint")):
+            interrupted = True
+        
+        save_conversation(conversation_file, prompt, response, response_time, interrupted)


### PR DESCRIPTION
This pull request introduces significant enhancements to the terminal-based conversational agent within our LLaMA 3 agents project. It focuses on improving user interaction and automatically saving conversation history in markdown files for better persistence and review.

Key Features
Automatic Saving of Conversations: Conversations with the LLM are now automatically saved in markdown files within the conversations directory, ensuring that all interactions are recorded and easily accessible for future reference.
Interactive Command Enhancements:
The new command has been added to allow users to start a new conversation seamlessly.
Early stopping of conversations is handled gracefully, with already generated outputs saved to the current conversation file, marked as "Interrupted" if incomplete.
Configuration and Convenience: The configuration file (config.json) dynamically updates to reflect the current active conversation, aiding in managing session continuity.
